### PR TITLE
fix: security issues (upgrade dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "chalk": "^2.3.1",
     "inquirer": "^5.1.0",
-    "jest": "^22.4.2",
+    "jest": "^25.4.0",
     "lodash.invoke": "^4.5.2",
     "lodash.isfunction": "^3.0.9",
     "lodash.partialright": "^4.2.1"
@@ -27,8 +27,8 @@
     "counter"
   ],
   "devDependencies": {
-    "@commitlint/cli": "^6.1.2",
-    "@commitlint/config-conventional": "^6.1.2",
+    "@commitlint/cli": "^8.3.5",
+    "@commitlint/config-conventional": "^8.3.4",
     "ansi-style-parser": "^2.0.0",
     "conventional-changelog-cli": "^1.3.15",
     "coveralls": "^3.0.0",


### PR DESCRIPTION
By upgrading dependencies (namely Jest) we fixed 66 security vulnerabilities. Closes #1 

I executed `npm test` locally and had a single test failing. I don't know how to fix it though, I'll leave it to you @jwarby 

